### PR TITLE
feat(Toolkit): add modelName property and use it in Toolkit constructor

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -117,6 +117,7 @@ class NpmSearch extends Tool {
 class Toolkit {
     openAIApiKey;
     serpApiKey;
+    modelName;
     tools;
     // Chain used to generate tool without use of other tools
     generatorChain;
@@ -125,6 +126,7 @@ class Toolkit {
     constructor(input) {
         this.openAIApiKey = input?.openAIApiKey;
         this.serpApiKey = input?.serpApiKey;
+        this.modelName = input?.modelName || 'gpt-4';
         this.tools = [new NpmSearch(), new NpmInfo(), new SerpAPI(this.serpApiKey)];
         const generatorPromptText = readFileSync(resolveFromSrc('templates/generate-tool-prompt.txt')).toString();
         this.constructGeneratorChain(generatorPromptText);
@@ -158,7 +160,7 @@ class Toolkit {
     }
     newLlmChain(prompt) {
         const llm = new OpenAI({
-            modelName: 'gpt-4',
+            modelName: this.modelName,
             temperature: 0,
             ...(this.openAIApiKey ? { openAIApiKey: this.openAIApiKey } : {}),
         });

--- a/src/Toolkit.ts
+++ b/src/Toolkit.ts
@@ -18,6 +18,7 @@ import NpmSearch from 'tools/NpmSearch';
 export type ToolkitInput = {
   openAIApiKey?: string;
   serpApiKey?: string;
+  modelName?: string;
 };
 
 export type GenerateToolInput = {
@@ -32,6 +33,8 @@ class Toolkit {
 
   private serpApiKey: string | undefined;
 
+  private modelName: string;
+
   private tools: LangChainTool[];
 
   // Chain used to generate tool without use of other tools
@@ -43,6 +46,7 @@ class Toolkit {
   constructor(input?: ToolkitInput) {
     this.openAIApiKey = input?.openAIApiKey;
     this.serpApiKey = input?.serpApiKey;
+    this.modelName = input?.modelName || 'gpt-4';
 
     this.tools = [new NpmSearch(), new NpmInfo(), new SerpAPI(this.serpApiKey)];
 
@@ -91,7 +95,7 @@ class Toolkit {
 
   private newLlmChain(prompt: PromptTemplate) {
     const llm = new OpenAI({
-      modelName: 'gpt-4',
+      modelName: this.modelName,
       temperature: 0,
       ...(this.openAIApiKey ? { openAIApiKey: this.openAIApiKey } : {}),
     });


### PR DESCRIPTION
The `modelName` property has been added, to be used in the `newLlmChain` method. This is due to the fact that I don't have gpt-4 access and therefore can't use this library without modifying this. This also extends the flexibility of Toolkit for future iterations of gpt's. It is worthwhile to compare what different models generate, too.

 If the `modelName` property is not provided, the default value of `gpt-4` is used, so those used to configuring toolkit as such shouldn't notice any change.